### PR TITLE
Add Honeycomb marker before starting the deploy

### DIFF
--- a/.github/workflows/deploy-image-to-k8s.yml
+++ b/.github/workflows/deploy-image-to-k8s.yml
@@ -78,10 +78,10 @@ jobs:
           chmod +x "$HOME/.local/bin/kustomize"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Deploy
-        run: script/deploy ${{ inputs.image }}
-
       - name: Add marker to Honeycomb
         run: |
           first_line=$(echo "${{ github.event.head_commit.message }}" | tr '\n' '\f' | sed -e 's/^\([^\f]*\).*$/\1/')
           curl https://api.honeycomb.io/1/markers/${{ inputs.honeycomb_dataset }} -X POST -H "X-Honeycomb-Team: ${{ secrets.HONEYCOMB_API_KEY }}" -d "{\"message\": \"$first_line\", \"url\": \"${{ github.event.head_commit.url }}\", \"type\": \"deploy\"}"
+
+      - name: Deploy
+        run: script/deploy ${{ inputs.image }}

--- a/.github/workflows/deploy-to-k8s.yml
+++ b/.github/workflows/deploy-to-k8s.yml
@@ -82,9 +82,6 @@ jobs:
           chmod +x "$HOME/.local/bin/kustomize"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Deploy
-        run: ${{ inputs.run }}
-
       - name: Add marker to Honeycomb
         run: |-
           <<<"$COMMIT_MESSAGE" read -r message_first_line
@@ -93,3 +90,6 @@ jobs:
             -X POST \
             -H "X-Honeycomb-Team: ${{ secrets.HONEYCOMB_API_KEY }}" \
             -d '{"type": "deploy", "message": "[${{ inputs.cluster_name }}] '"$message_first_line"'", "url": "'"$COMMIT_URL"'"}'
+
+      - name: Deploy
+        run: ${{ inputs.run }}


### PR DESCRIPTION
The rollout of the new version has already started by the time our deploy step has finished. In the case where the deploy action takes longer than expected for some reason, adding the deploy marker afterwards means we've got some production impact happening without a marker for a little while.

The downside to swapping it round is that we'll have rogue markers if the deploy doesn't happen for some reason. We can probably keep a reference to the marker and update it to indicate it failed to solve that.