### PR TITLE
Use cheaper runner for `buildx`

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -37,7 +37,7 @@ on:
 jobs:
   build:
     name: Build and push
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
 
     if: ${{ github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
 


### PR DESCRIPTION
16-cores costs $0.064/minute. The default 2-cores costs $0.008/minute.