### PR TITLE
deploy-to-k8s: support AWS auth

### DIFF
--- a/.github/workflows/deploy-to-k8s.yml
+++ b/.github/workflows/deploy-to-k8s.yml
@@ -24,13 +24,15 @@ on:
       auth_method:
         required: true
         type: string
-        description: How to authenticate to the cluster (one of "kubeconfig", "gke").
+        description: How to authenticate to the cluster (one of "kubeconfig", "aws", "gke").
       auth_params:
         type: string
         description: >
           Auth payload for the specified auth mechanism. For auth_method "gke"
           this should be a JSON string representing the inputs to
-          google-github-actions/get-gke-credentials.
+          google-github-actions/get-gke-credentials. For auth_method "aws" this
+          should be a JSON string with keys: `role_arn`,
+          `role_session_name`, `aws_region` and `cluster_name`.
       run:
         required: true
         type: string
@@ -71,14 +73,27 @@ jobs:
       COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       COMMIT_URL: ${{ github.event.head_commit.url }}
 
+      AWS_REGION: ${{ inputs.auth_method == 'aws' && fromJSON(inputs.auth_params)['aws_region'] }}
+      AWS_ROLE_SESSION_NAME: ${{ inputs.auth_method == 'aws' && fromJSON(inputs.auth_params)['role_session_name'] }}
+      AWS_ROLE_ARN: ${{ inputs.auth_method == 'aws' && fromJSON(inputs.auth_params)['role_arn'] }}
+      AWS_CLUSTER_NAME: ${{ inputs.auth_method == 'aws' && fromJSON(inputs.auth_params)['cluster_name'] }}
+
     steps:
       - uses: actions/checkout@v4
 
       - name: Validate auth method
-        if: ${{ inputs.auth_method != 'gke' && inputs.auth_method != 'kubeconfig' }}
+        if: ${{ inputs.auth_method != 'aws' && inputs.auth_method != 'gke' && inputs.auth_method != 'kubeconfig' }}
         run: |-
-          echo "Invalid auth method: must be one of kubeconfig, gke" >&2
+          echo "Invalid auth method: must be one of kubeconfig, aws, gke" >&2
           exit 1
+
+      - name: Authenticate to AWS
+        uses: aws-actions/configure-aws-credentials@v3
+        if: ${{ inputs.auth_method == 'aws' }}
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: ${{ env.AWS_ROLE_SESSION_NAME }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Authenticate to Google Cloud
         if: ${{ inputs.auth_method == 'gke' || inputs.install_sops }}
@@ -86,6 +101,10 @@ jobs:
         with:
           workload_identity_provider: projects/1025538909507/locations/global/workloadIdentityPools/github/providers/github-actions
           service_account: deploy@replicate-production.iam.gserviceaccount.com
+
+      - name: Install cluster credentials (AWS)
+        if: ${{ inputs.auth_method == 'aws' }}
+        run: aws eks update-kubeconfig --name ${{ env.AWS_CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
 
       - name: Install cluster credentials (GKE)
         if: ${{ inputs.auth_method == 'gke' }}


### PR DESCRIPTION
This updates deploy-to-k8s to support AWS auth.  It uses configure-aws-credentials to assume an AWS role, and the AWS CLI to set kubeconfig for the given cluster.