### PR TITLE
Add OCI Workflow Authentication

### DIFF
--- a/.github/workflows/deploy-to-k8s.yml
+++ b/.github/workflows/deploy-to-k8s.yml
@@ -24,15 +24,22 @@ on:
       auth_method:
         required: true
         type: string
-        description: How to authenticate to the cluster (one of "kubeconfig", "oci", "aws", "gke").
+        description: How to authenticate to the cluster (one of "kubeconfig", "aws", "gke", "oci").
       auth_params:
         type: string
         description: >
-          Auth payload for the specified auth mechanism. For auth_method "gke"
-          this should be a JSON string representing the inputs to
-          google-github-actions/get-gke-credentials. For auth_method "aws" this
-          should be a JSON string with keys: `role_arn`,
-          `role_session_name`, `aws_region` and `cluster_name`.
+          Auth payload for the specified auth mechanism.
+
+          For auth_method "aws" this should be a JSON string with keys:
+          `role_arn`, `role_session_name`, `aws_region` and `cluster_name`.
+
+          For auth_method "gke" this should be a JSON string representing the
+          inputs to google-github-actions/get-gke-credentials.
+
+          For auth method "oci" this should be a JSON string with keys:
+          `oci_cli_user`, `oci_cli_tenancy`, `oci_cli_fingerprint`,
+          `oci_cli_region`. You must also provide the secret
+          `OCI_CLI_KEY_CONTENT`.
       run:
         required: true
         type: string
@@ -85,21 +92,13 @@ jobs:
       AWS_ROLE_ARN: ${{ inputs.auth_method == 'aws' && fromJSON(inputs.auth_params)['role_arn'] }}
       AWS_CLUSTER_NAME: ${{ inputs.auth_method == 'aws' && fromJSON(inputs.auth_params)['cluster_name'] }}
 
-      OCI_CLI_USER: ${{ inputs.auth_method == 'oci' && secrets.OCI_CLI_USER }}
-      OCI_CLI_TENANCY: ${{ inputs.auth_method == 'oci' && secrets.OCI_CLI_TENANCY }}
-      OCI_CLI_FINGERPRINT: ${{ inputs.auth_method == 'oci' && secrets.OCI_CLI_FINGERPRINT }}
-      OCI_CLI_KEY_CONTENT: ${{ inputs.auth_method == 'oci' && secrets.OCI_CLI_KEY_CONTENT }}
-      OCI_CLI_REGION: ${{ inputs.auth_method == 'oci' && secrets.OCI_CLI_REGION }}
-      OKE_CLUSTER_ID: ${{ inputs.auth_method == 'oci' && secrets.OKE_CLUSTER_ID }}
-
-
     steps:
       - uses: actions/checkout@v4
 
       - name: Validate auth method
-        if: ${{ inputs.auth_method != 'aws' && inputs.auth_method != 'gke' && inputs.auth_method != 'kubeconfig' && inputs.auth_method != 'oci' }}
+        if: ${{ ! contains(fromJSON('["kubeconfig", "aws", "gke", "oci"]'), inputs.auth_method) }}
         run: |-
-          echo "Invalid auth method: must be one of kubeconfig, oci, aws, gke" >&2
+          echo "Invalid auth method: must be one of kubeconfig, aws, gke, oci" >&2
           exit 1
 
       - name: Authenticate to AWS
@@ -117,12 +116,6 @@ jobs:
           workload_identity_provider: projects/1025538909507/locations/global/workloadIdentityPools/github/providers/github-actions
           service_account: deploy@replicate-production.iam.gserviceaccount.com
 
-      - name: Setup Kubectl for Oracle Cloud OKE (OCI)
-        if: ${{ inputs.auth_method == 'oci' }}
-        uses: oracle-actions/configure-kubectl-oke@v1.3.2
-        with:
-          cluster: ${{ env.OKE_CLUSTER_ID }}
-
       - name: Install cluster credentials (AWS)
         if: ${{ inputs.auth_method == 'aws' }}
         run: aws eks update-kubeconfig --name ${{ env.AWS_CLUSTER_NAME }} --region ${{ env.AWS_REGION }}
@@ -131,6 +124,18 @@ jobs:
         if: ${{ inputs.auth_method == 'gke' }}
         uses: google-github-actions/get-gke-credentials@v2
         with: ${{ fromJSON(inputs.auth_params) }}
+
+      - name: Install cluster credentials (OCI)
+        if: ${{ inputs.auth_method == 'oci' }}
+        env:
+          OCI_CLI_USER: ${{ fromJSON(inputs.auth_params)['oci_cli_user'] }}
+          OCI_CLI_TENANCY: ${{ fromJSON(inputs.auth_params)['oci_cli_tenancy'] }}
+          OCI_CLI_FINGERPRINT: ${{ fromJSON(inputs.auth_params)['oci_cli_fingerprint'] }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
+          OCI_CLI_REGION: ${{ fromJSON(inputs.auth_params)['oci_cli_region'] }}
+        uses: oracle-actions/configure-kubectl-oke@v1.3.2
+        with:
+          cluster: ${{ env.OKE_CLUSTER_ID }}
 
       - name: Install cluster credentials (kubeconfig)
         if: ${{ inputs.auth_method == 'kubeconfig' }}


### PR DESCRIPTION
Add OCI Workflow authentication to common actions. This allows for kubectl to be setup appropriately with credentials to interact with OKE clusters.

This relies on proper secrets being available to the action.