### PR TITLE
Set org.opencontainers.image.title explicitly

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -69,6 +69,8 @@ jobs:
         tags: |
           type=sha
           type=raw,value=latest,enable={{is_default_branch}},priority=0
+        labels: |
+          org.opencontainers.image.title=${{ inputs.image }}
 
     - name: 'Set up Buildx'
       uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
I had an action fail when the built image had a name that differed from the repository name:
https://github.com/replicate/infra/actions/runs/8817778926/job/24205953769

docker/metadata-action assumes that org.opencontainers.image.title should be the repoository name, and we use this label for the `image` output, which is wrong.

We can fix this by overriding the default value of the org.opencontainers.image.title label to the `image` input.