### PR TITLE
Push all images to AWS us-west-2 as well

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -66,6 +66,7 @@ jobs:
         images: |
           us-docker.pkg.dev/replicate-production/replicate-services-us/${{ inputs.image }}
           851725545228.dkr.ecr.us-east-1.amazonaws.com/${{ inputs.image }}
+          851725545228.dkr.ecr.us-west-2.amazonaws.com/${{ inputs.image }}
         tags: |
           type=sha
           type=raw,value=latest,enable={{is_default_branch}},priority=0


### PR DESCRIPTION
https://github.com/replicate/cluster/pull/1820 must be merged first to ensure the repositories exist there.