### PR TITLE
Support dryrun builds

### DIFF
--- a/.github/workflows/deploy-to-k8s.yml
+++ b/.github/workflows/deploy-to-k8s.yml
@@ -87,7 +87,11 @@ jobs:
       AWS_ROLE_SESSION_NAME: ${{ inputs.auth_method == 'aws' && fromJSON(inputs.auth_params)['role_session_name'] }}
       AWS_ROLE_ARN: ${{ inputs.auth_method == 'aws' && fromJSON(inputs.auth_params)['role_arn'] }}
       AWS_CLUSTER_NAME: ${{ inputs.auth_method == 'aws' && fromJSON(inputs.auth_params)['cluster_name'] }}
-      DRYRUN: ${{ inputs.dryrun && 'yes' || '' }}
+      DRYRUN: |
+        ${{
+        inputs.dryrun
+        && !((github.event_name == 'workflow_dispatch' || github.event_name == 'push') && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch)))
+        && 'yes' || '' }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This is step one of attaching kubectl diff output to PR builds.  They need to run if we are to get diff output!