### PR TITLE
Run build and push only on main

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -39,7 +39,7 @@ jobs:
     name: Build and push
     runs-on: ubuntu-latest-8-cores
 
-    if: ${{ github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork }}
+    if: github.ref == 'refs/heads/main'
 
     permissions:
       contents: 'read'


### PR DESCRIPTION
Looks like we're pushing images on PR runs, probably unintended? https://github.com/replicate/director/actions/runs/10170036625

I had to add this condition to my build:
https://github.com/replicate/fuse-rpc/blob/main/.github/workflows/ci.yml#L42