### PR TITLE
Support dry-run deployments, take two

### DIFF
--- a/.github/workflows/deploy-to-k8s.yml
+++ b/.github/workflows/deploy-to-k8s.yml
@@ -71,11 +71,15 @@ on:
       KUBECONFIG:
         required: false
 
+env:
+  SHOULD_DEPLOY: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) && 'yes' || '' }}
+
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
 
+    # this is ${{ inputs.dryrun || env.SHOULD_DEPLOY }}, but the `env` context isn't available here
     if: ${{ inputs.dryrun || (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) }}
 
     env:
@@ -86,11 +90,6 @@ jobs:
       AWS_ROLE_SESSION_NAME: ${{ inputs.auth_method == 'aws' && fromJSON(inputs.auth_params)['role_session_name'] }}
       AWS_ROLE_ARN: ${{ inputs.auth_method == 'aws' && fromJSON(inputs.auth_params)['role_arn'] }}
       AWS_CLUSTER_NAME: ${{ inputs.auth_method == 'aws' && fromJSON(inputs.auth_params)['cluster_name'] }}
-      DRYRUN: |-
-        ${{
-        inputs.dryrun
-        && !((github.event_name == 'workflow_dispatch' || github.event_name == 'push') && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch)))
-        && 'yes' || '' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -181,7 +180,7 @@ jobs:
         run: ${{ inputs.dryrun }}
 
       - name: Deploy
-        if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) }}
+        if: ${{ env.SHOULD_DEPLOY }}
         run: ${{ inputs.run }}
 
       - name: Update deployment marker


### PR DESCRIPTION
The first version of this had a critical bug that DRYRUN was always being set to a nonzero-length string because it included the trailing newline.  This meant that all deploys were run in dry-run mode.

This attempts to fix that.  I will test it actually works before merging!