### PR TITLE
Allow passing in additional `build-args` to docker/build-push-action

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -34,6 +34,11 @@ on:
         type: string
         default: linux/amd64,linux/arm64
         description: The platforms to build the docker image against.
+      build-args:
+        required: false
+        type: string
+        default: ''
+        description: Additional build-args argument passed to docker/build-push-action.
       fetch-depth:
         required: false
         type: number
@@ -118,3 +123,4 @@ jobs:
         cache-to: type=gha,scope=${{ inputs.image }},mode=max
         build-args: |
           COMMIT_SHA=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+          ${{ inputs.build-args }}


### PR DESCRIPTION
through which I am intending to pass `BUILDKIT_CONTEXT_KEEP_GIT_DIR=1` [ref](https://docs.docker.com/reference/dockerfile/#example-keep-git-dir).