### PR TITLE
Pass through `file` arg to docker/build-push-action

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -44,6 +44,9 @@ on:
         type: number
         default: 1
         description: The fetch depth passed to actions/checkout.
+      file:
+        required: false
+        description: Path to the Dockerfile passed to docker/build-push-action.
     outputs:
       image:
         description: "The built image identifier"
@@ -115,6 +118,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: ${{ inputs.context }}
+        file: ${{ inputs.file || '' }}
         push: true
         platforms: ${{ inputs.platforms }}
         tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
in a way that doesn't blow up. This is based on the `v5` action not using a default value for `file` and then the javascript truthiness of the value being used to decide to append a `--file` argument.

An empty string is false-y and `||` is allowed within a github actions expression, so this should be `undefined || ''` when no `file` value is provided, meaning no `--file` argument is appended to the build arguments.