### PR TITLE
Allow injecting go build cache

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -49,6 +49,11 @@ on:
         type: string
         default: ''
         description: Path to the Dockerfile passed to docker/build-push-action.
+      enable-go-build-cache:
+        required: false
+        type: boolean
+        default: false
+        description: Whether to add a GitHub Actions cache instance at /root/.cache/go-build
     outputs:
       image:
         description: "The built image identifier"
@@ -116,6 +121,29 @@ jobs:
         username: oauth2accesstoken
         password: '${{ steps.auth.outputs.access_token }}'
 
+    - name: "Create go build cache"
+      uses: actions/cache@v3
+      id: go-build-cache
+      if: ${{ inputs.enable-go-build-cache }}
+      with:
+        path: |
+          go-build-cache
+          go-mod-cache
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: 'Inject go build cache into docker'
+      uses: reproducible-containers/buildkit-cache-dance@v3.1.2
+      if: ${{ inputs.enable-go-build-cache }}
+      with:
+        cache-map: |
+          {
+            "go-build-cache": "/root/.cache/go-build",
+            "go-mod": "/root/go/pkg/mod"
+          }
+        # Only save the cache from the main branch. Not worth saving build cache from PR builds.
+        skip-extraction: |
+          ${{ steps.go-build-cache.outputs.cache-hit || github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
     - name: 'Build and push'
       uses: docker/build-push-action@v5
       with:


### PR DESCRIPTION
Based on https://docs.docker.com/build/ci/github-actions/cache/#cache-mounts

Currently we rebuild every go file on every CI build that changes any go code. We should cache build outputs so that we only build new files.

This adds an option to create a GitHub Actions cache and inject it into the docker build process.

The design of this is such that:

- we choose a cache key in the form: Linux-go-${{ hashFiles('**/go.sum') }}
- we try to restore from that exact cache key
- if we don't find anything, we restore from _any_ cache key beginning Linux-go-
- at the end of the run, if it's a default branch build, and we had a cache miss in step 2, we save the cache.

We don't bother saving artifacts from PR builds.

This is slightly imperfect, in that the cache key doesn't change when go source files change, which means if (say) pkg/foo.go changes, we won't save the built output of pkg/foo.go to the cache (because we had an exact match cache hit). But saving the cache is actually quite an expensive operation (on the order of order of 1-2 minutes), so it's actually good for us to use an imperfect cache which is only invalidated by go.sum updates, rather than a perfect cache that's invalidated by changing any *.go file.